### PR TITLE
Include debug symbols in build; and bump to 2.29

### DIFF
--- a/build/build-thttpd-static
+++ b/build/build-thttpd-static
@@ -8,5 +8,5 @@ tar xf thttpd-${THTTPD_VERSION}.tar.gz
 cd thttpd-${THTTPD_VERSION}
 patch -p1 < /build/thttpd-runasroot.patch
 ./configure
-make CCOPT='-O2 -static' thttpd
-install -m 755 -s thttpd /build
+make CCOPT='-O2 -g -static' thttpd
+install -m 755 thttpd /build

--- a/build/build-thttpd-static
+++ b/build/build-thttpd-static
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-: ${THTTPD_VERSION:=2.26}
+: ${THTTPD_VERSION:=2.29}
 
 set -e
 curl -sf -o thttpd-${THTTPD_VERSION}.tar.gz http://acme.com/software/thttpd/thttpd-${THTTPD_VERSION}.tar.gz


### PR DESCRIPTION
Put debug symbols into the build so that tools like perf and flame graphs will work.

Bump to 2.29 while we are at it.